### PR TITLE
Fix CI badge status https://github.com/badges/shields/issues/8671

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Regex
 
-[![Build Status](https://img.shields.io/github/workflow/status/nitely/nim-regex/CI/master?style=flat-square)](https://github.com/nitely/nim-regex/actions?query=workflow%3ACI)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/nitely/nim-regex/ci.yml?style=flat-square)](https://github.com/nitely/nim-regex/actions?query=workflow%3ACI)
 [![licence](https://img.shields.io/github/license/nitely/nim-regex.svg?style=flat-square)](https://raw.githubusercontent.com/nitely/nim-regex/master/LICENSE)
 
 A library for parsing, compiling, and executing regular expressions.


### PR DESCRIPTION
Badge currently looks like this
![image](https://user-images.githubusercontent.com/19339842/216793863-0c19df74-1ef2-4c73-8b0c-16fb75561533.png)
Going to the issue said to update the URL to how it is in this PR

After PR it now looks like
![image](https://user-images.githubusercontent.com/19339842/216793884-7ecba7ba-324a-4222-a55f-79972961169c.png)
